### PR TITLE
Update Dockerfile to use distroless base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY . .
 RUN go mod download && \
     CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o bin/kubeslice-router-sidecar main.go
 
-# Build reduced image from base alpine
+# Build reduced image from distroless-base image
 FROM gcr.io/distroless/static
 
 # Add the necessary pakages:

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,12 +34,12 @@ RUN go mod download && \
     CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o bin/kubeslice-router-sidecar main.go
 
 # Build reduced image from base alpine
-FROM alpine:3.21
+FROM gcr.io/distroless/static
 
 # Add the necessary pakages:
 # tc - is needed for traffic control and shaping on the sidecar.  it is part of the iproute2
-RUN apk add --no-cache ca-certificates &&\
-    apk add iproute2
+COPY --from=gobuilder /kubeslice/kubeslice-router-sidecar/bin/kubeslice-router-sidecar /router-sidecar
+ENTRYPOINT ["/router-sidecar"]
 
 # Run the sidecar binary.
 WORKDIR /kubeslice


### PR DESCRIPTION
### Fixes #50 

This PR updates the Dockerfile to use a distroless base image (gcr.io/distroless/static) instead of Alpine.
It changes the image size to 37.08 MB and the build is sucessful, as shown in screenshot.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/de24dbf0-f9e4-49c2-b747-a916336dc1f1" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/566e7f0d-da11-436b-b0ab-3c1a16f99f21" />
